### PR TITLE
fix axis nomenclature mixup in filter_data_completeness

### DIFF
--- a/src/alphatools/pp/data.py
+++ b/src/alphatools/pp/data.py
@@ -445,7 +445,7 @@ def filter_data_completeness(
     max_missing: float,
     group_column: str | None = None,
     groups: list[str] | None = None,
-    axis: int = 0,
+    axis: int = 1,
 ) -> ad.AnnData:
     """Filter data based on missing values
 
@@ -468,7 +468,7 @@ def filter_data_completeness(
     groups : list[str], optional
         List of groups to consider in filtering.
     axis : int, optional
-        Whether to check completeness of samples (0) or features (1).
+        Whether to check completeness of features (0) or samples (1).
 
     """
     if max_missing < 0 or max_missing > 1:
@@ -482,11 +482,11 @@ def filter_data_completeness(
     if not is_numeric_dtype(adata.X):
         raise ValueError("Data must be numeric.")
 
-    if axis == 0:  # check completeness of samples
+    if axis == 1:  # check completeness of samples
         missing_fraction = np.isnan(adata.X).mean(axis=1)
         missing_above_cutoff = missing_fraction > max_missing
         adata = adata[~missing_above_cutoff, :]
-    elif axis == 1:  # check completeness of features
+    elif axis == 0:  # check completeness of features
         missing_fraction = np.isnan(adata.X).mean(axis=0)
         missing_above_cutoff = missing_fraction > max_missing
         adata = adata[:, ~missing_above_cutoff]

--- a/tests/pp/test_data.py
+++ b/tests/pp/test_data.py
@@ -781,28 +781,28 @@ def data_test_completeness_filter():
             ["A", "B", "C"],
             ["cell1", "cell2", "cell3", "cell4", "cell5"],
             0.5,
-            1,
+            0,
         ),
         # 1.2. Filter columns with 0.6 threshold so that one value lies exactly on the threshold --> this should be kept since ">" is used
         (
             ["A", "B", "C", "D"],
             ["cell1", "cell2", "cell3", "cell4", "cell5"],
             0.6,
-            1,
+            0,
         ),
         # 1.3. Filter columns with 1.0 threshold: keep all columns
         (
             ["A", "B", "C", "D", "E"],
             ["cell1", "cell2", "cell3", "cell4", "cell5"],
             1.0,
-            1,
+            0,
         ),
         # 1.4. Filter columns with 0.0 threshold: remove columns with any missing values
         (
             ["A"],
             ["cell1", "cell2", "cell3", "cell4", "cell5"],
             0.0,
-            1,
+            0,
         ),
         # 2. Check filtering of rows (samples)
         # 2.1. Filter rows with 0.5 threshold
@@ -810,28 +810,28 @@ def data_test_completeness_filter():
             ["A", "B", "C", "D", "E"],
             ["cell3", "cell4", "cell5"],
             0.5,
-            0,
+            1,
         ),
         # 2.2. Filter rows with 0.6 threshold so that one value lies exactly on the threshold --> this should be kept since ">" is used
         (
             ["A", "B", "C", "D", "E"],
             ["cell2", "cell3", "cell4", "cell5"],
             0.6,
-            0,
+            1,
         ),
         # 2.3. Filter rows with 1.0 threshold: keep all rows
         (
             ["A", "B", "C", "D", "E"],
             ["cell1", "cell2", "cell3", "cell4", "cell5"],
             1.0,
-            0,
+            1,
         ),
         # 2.4. Filter rows with 0.0 threshold: remove rows with any missing values
         (
             ["A", "B", "C", "D", "E"],
             ["cell5"],
             0.0,
-            0,
+            1,
         ),
     ],
 )


### PR DESCRIPTION
Now the 'axis' argument complies with Pandas/Numpy convention where 0 means that we operate along the rows and 1 means that we operate along the columns. I.e. When filtering for completeness of features (columns), we need to set axis = 0, since we perform the operation across rows for each feature.