### PR TITLE
first draft of additional feature column support for AnnDataFactory

### DIFF
--- a/src/alphatools/io/anndata_factory.py
+++ b/src/alphatools/io/anndata_factory.py
@@ -8,6 +8,8 @@ import pandas as pd
 from alphabase.psm_reader import PSMReaderBase
 from alphabase.psm_reader.keys import PsmDfCols
 
+from alphatools.pp.data import add_metadata
+
 
 class AnnDataFactory:
     """Factory class to convert AlphaBase PSM DataFrames to AnnData format."""
@@ -31,24 +33,13 @@ class AnnDataFactory:
 
         self._psm_df = psm_df
 
-        # # Warn if duplicated features exist which get dropped;
-        # # TODO: This is not relevant for protein-level analysis, since there it is expected to have duplicated features
-        # # (i.e. the same protein id will almost inevitably have more than one precursor per file). However, if the analysis
-        # # level is precursors, we would not expect to see duplicated precursor IDs in the same file. In the future, there should
-        # # be an explicit flag to indicate whether we are analysing proteins or precursors, and whether the warning
-        # # below should be shown
-        # duplicated_features: pd.Series = self._psm_df.groupby(PsmDfCols.RAW_NAME).apply(
-        #     lambda df: df[PsmDfCols.PROTEINS].duplicated().sum(), include_groups=False
-        # )
-
-        # if any(duplicated_features > 0):
-        #     warnings.warn(
-        #         f"Found {duplicated_features.sum()} duplicated features. Using only first.",
-        #         stacklevel=1,
-        #     )
-
-    def create_anndata(self) -> ad.AnnData:
+    def create_anndata(self, secondary_id_columns: str | list[str] | None = None) -> ad.AnnData:
         """Create AnnData object from PSM DataFrame.
+
+        Parameters
+        ----------
+        secondary_id_columns : Union[str, List[str]], optional
+            Additional columns to include in `var` of the AnnData object, by default None
 
         Returns
         -------
@@ -59,6 +50,19 @@ class AnnDataFactory:
             - X contains intensity values
 
         """
+        # Extract additional feature metadata if needed
+        if secondary_id_columns:
+            if isinstance(secondary_id_columns, str):
+                secondary_id_columns = [secondary_id_columns]
+        else:
+            secondary_id_columns = []
+
+        # Ensure PsmDfCols.PROTEINS is included in feature metadata
+        if PsmDfCols.PROTEINS not in secondary_id_columns:
+            secondary_id_columns.append(PsmDfCols.PROTEINS)
+
+        feature_metadata = self._psm_df[secondary_id_columns].drop_duplicates().set_index(PsmDfCols.PROTEINS, drop=True)
+
         # Create pivot table: raw names x proteins with intensity values
         pivot_df = pd.pivot_table(
             self._psm_df,
@@ -70,10 +74,19 @@ class AnnDataFactory:
             dropna=False,
         )
 
-        return ad.AnnData(
+        adata = ad.AnnData(
             X=pivot_df.values,
             obs=pd.DataFrame(index=pivot_df.index),
             var=pd.DataFrame(index=pivot_df.columns),
+        )
+
+        # Add feature metadata to var of the resulting AnnData
+        return add_metadata(
+            adata=adata,
+            incoming_metadata=feature_metadata,
+            axis=1,
+            keep_data_shape=True,
+            verbose=False,
         )
 
     @classmethod
@@ -83,8 +96,8 @@ class AnnDataFactory:
         reader_type: str = "maxquant",
         *,
         intensity_column: str | None = None,
-        protein_id_column: str | None = None,
-        raw_name_column: str | None = None,
+        feature_id_column: str | None = None,
+        sample_id_column: str | None = None,
         **kwargs,
     ) -> "AnnDataFactory":
         """Create AnnDataFactory from PSM files.
@@ -120,8 +133,8 @@ class AnnDataFactory:
             k: v
             for k, v in {
                 PsmDfCols.INTENSITY: intensity_column if intensity_column else None,
-                PsmDfCols.PROTEINS: protein_id_column if protein_id_column else None,
-                PsmDfCols.RAW_NAME: raw_name_column if raw_name_column else None,
+                PsmDfCols.PROTEINS: feature_id_column if feature_id_column else None,
+                PsmDfCols.RAW_NAME: sample_id_column if sample_id_column else None,
             }.items()
             if v is not None
         }

--- a/src/alphatools/io/psm_reader.py
+++ b/src/alphatools/io/psm_reader.py
@@ -10,6 +10,7 @@ def read_psm_table(
     intensity_column: str | None = None,
     feature_id_column: str | None = None,
     sample_id_column: str | None = None,
+    secondary_feature_columns: str | list[str] | None = None,
     **kwargs,
 ) -> ad.AnnData:
     """Read peptide spectrum match tables to the :class:`anndata.AnnData` format
@@ -41,6 +42,9 @@ def read_psm_table(
     sample_id_column
         Column that holds the sample identifier in the PSM table. Defaults to the pre-configured value
         in `alphabase`.
+    secondary_feature_columns
+        Additional columns to annotate features in the `adata.var` table. Can be a single column name or a list of column names.
+        Defaults to None.
     **kwargs
         Keyword arguments passed to :meth:`alphabase.psm_reader.psm_reader_provider.get_reader`
 
@@ -76,7 +80,7 @@ def read_psm_table(
         file_paths=file_paths,
         reader_type=search_engine,
         intensity_column=intensity_column,
-        protein_id_column=feature_id_column,
-        raw_name_column=sample_id_column,
+        feature_id_column=feature_id_column,
+        sample_id_column=sample_id_column,
         **kwargs,
-    ).create_anndata()
+    ).create_anndata(secondary_id_columns=secondary_feature_columns)

--- a/tests/integration/test_anndata.py
+++ b/tests/integration/test_anndata.py
@@ -86,8 +86,8 @@ def test_anndata_diann_181():
         factory = AnnDataFactory.from_files(
             file_paths=file_path,
             reader_type="diann",
-            raw_name_column="File.Name",
-            protein_id_column="Protein.Group",
+            sample_id_column="File.Name",
+            feature_id_column="Protein.Group",
             intensity_column="PG.MaxLFQ",
         )
 
@@ -107,8 +107,8 @@ def test_anndata_diann_190():
         factory = AnnDataFactory.from_files(
             file_paths=file_path,
             reader_type="diann",
-            raw_name_column="File.Name",
-            protein_id_column="Protein.Group",
+            sample_id_column="File.Name",
+            feature_id_column="Protein.Group",
             intensity_column="PG.MaxLFQ",
         )
 


### PR DESCRIPTION
[not done] Adding functionality to retain feature metadata in the AnnDataFactory

This PR relates to https://github.com/MannLabs/alphabase/pull/255#discussion_r1854153079, but it seems like this is an alphatools rather than an alphabase issue since it concerns the AnnDataFactory.

Key insights so far:
- When aggregating on precursor level, we need to somehow be able to retain the gene-level information in the anndata var instance for downstream analyses
- Similar story when aggregating on proteins and keeping gene names around etc.

A first implementation exists in this PR and runs when used like this:

```
    adata_precursor = io.read_psm_table(
        file_paths=file_path,
        search_engine="diann",
        intensity_column="Precursor.Normalised",
        feature_id_column="Precursor.Id",
        sample_id_column="Run",
        secondary_feature_columns=["proteins", "genes", "sequence"],
    )
```

However, there is a problem when running it like this:
```

    adata_gene = io.read_psm_table(
        file_paths=file_path,
        search_engine="diann",
        intensity_column="Genes.MaxLFQ",
        feature_id_column="Genes",
        sample_id_column="Run",
        secondary_feature_columns=["proteins"],
    )
```

The expected output would be a gene level index and a column called "proteins" which contains the first protein group associated with this gene [*]. However, the output is a dataframe with a 'proteins' index that contains gene names and no proteins column at all. The core issue here is that the alphatools-standardized name "proteins" is associated with whatever feature ID we supply, regardless of whether features are proteins, peptides or genes. [**]

Required fixes:
[*]: There could be a logically sound fix for this in an aggregation function that is smarter than just "first": if the column is numeric, aggregate by "first", if the column is non-numeric, concatenate with ";". That way we leave it up to the user what metadata they want to keep, knowing they'll get a concatenated string for each feature.

[**]: This is harder to address because it highlights the antipattern of using "proteins" as an identifier for any feature. Unclear how to solve this so far, perhaps by translating to a generic "feature" column?




