### PR TITLE
Peptide feature level

### DIFF
--- a/src/alphapepttools/io/peptide_level.py
+++ b/src/alphapepttools/io/peptide_level.py
@@ -1,0 +1,329 @@
+import anndata as ad
+import pandas as pd
+
+
+def _create_peptide_group_id(sequence: pd.Series, protein_id: pd.Series, separator: str = "_IN_") -> pd.Series:
+    """Create unique identifier by concatenating sequence and protein ID.
+
+    Parameters
+    ----------
+    sequence : pd.Series
+        Peptide sequences
+    protein_id : pd.Series
+        Protein identifiers
+    separator : str, optional
+        Separator string between sequence and protein ID (default: "_IN_")
+
+    Returns
+    -------
+    pd.Series
+        Concatenated identifiers
+    """
+    return sequence.astype(str) + separator + protein_id.astype(str)
+
+
+def _parse_peptide_group_id(group_id: pd.Index, separator: str = "_IN_") -> tuple[pd.Series, pd.Series]:
+    """Parse peptide group ID back into sequence and protein ID components.
+
+    Parameters
+    ----------
+    group_id : pd.Index
+        Concatenated peptide group identifiers
+    separator : str, optional
+        Separator string used in concatenation (default: "_IN_")
+
+    Returns
+    -------
+    tuple[pd.Series, pd.Series]
+        Tuple of (sequence, protein_id) Series
+    """
+    split = group_id.str.split(separator, n=1)
+    sequence = split.str[0]
+    protein_id = split.str[1]
+    return sequence, protein_id
+
+
+def _extract_quantification_data(adata: ad.AnnData, sequence_column: str, protein_id_column: str) -> pd.DataFrame:
+    """Extract quantification matrix with sequence and protein metadata.
+
+    Parameters
+    ----------
+    adata : ad.AnnData
+        Input AnnData object with peptides/precursors as variables
+    sequence_column : str
+        Column name for peptide sequences
+    protein_id_column : str
+        Column name for protein identifiers
+
+    Returns
+    -------
+    pd.DataFrame
+        Quantification data with sequence and protein ID columns
+    """
+    # Transpose so peptides are rows
+    adata_t = adata.T.copy()
+
+    # Join quantification data with metadata
+    metadata_columns = [sequence_column, protein_id_column]
+    return adata_t.to_df().join(adata_t.obs[metadata_columns])
+
+
+def _aggregate_by_sequence_and_protein(
+    data_df: pd.DataFrame,
+    sequence_column: str,
+    protein_id_column: str,
+    aggregation: str,
+) -> pd.DataFrame:
+    """Aggregate peptide data by sequence and protein group.
+
+    Groups identical peptide sequences within the same protein group,
+    aggregating quantification values and removing duplicates.
+
+    Parameters
+    ----------
+    data_df : pd.DataFrame
+        Quantification dataframe with sequence and protein ID columns
+    sequence_column : str
+        Column name for peptide sequences
+    protein_id_column : str
+        Column name for protein identifiers
+    aggregation : str
+        Aggregation method (e.g., 'max', 'mean', 'median')
+
+    Returns
+    -------
+    pd.DataFrame
+        Aggregated data with group ID as index
+    """
+    # Create composite grouping identifier
+    group_id = _create_peptide_group_id(data_df[sequence_column], data_df[protein_id_column])
+    data_df["_group_id"] = group_id
+
+    # Drop metadata columns before aggregation
+    quant_df = data_df.drop(columns=[sequence_column, protein_id_column])
+
+    # Aggregate by group ID
+    aggregated_df = quant_df.groupby("_group_id", observed=False).agg(aggregation)
+
+    # Remove duplicates (same stripped sequence in protein group)
+    aggregated_df = aggregated_df.drop_duplicates()
+
+    # Parse group ID back into sequence and protein columns
+    sequence, protein_id = _parse_peptide_group_id(aggregated_df.index)
+    aggregated_df[sequence_column] = sequence
+    aggregated_df[protein_id_column] = protein_id
+
+    return aggregated_df
+
+
+def _add_metadata_columns(
+    aggregated_df: pd.DataFrame,
+    adata_obs: pd.DataFrame,
+    sequence_column: str,
+    protein_id_column: str,
+    added_columns: list[str],
+) -> pd.DataFrame:
+    """Merge additional metadata columns into aggregated dataframe.
+
+    Parameters
+    ----------
+    aggregated_df : pd.DataFrame
+        Aggregated quantification data
+    adata_obs : pd.DataFrame
+        Original AnnData.obs with metadata
+    sequence_column : str
+        Column name for peptide sequences
+    protein_id_column : str
+        Column name for protein identifiers
+    added_columns : list[str]
+        Additional metadata columns to include
+
+    Returns
+    -------
+    pd.DataFrame
+        Aggregated data with additional metadata merged
+    """
+    # remove sequence_column and protein_id_column from added_columns if they are present
+    added_columns = [col for col in added_columns if col not in [sequence_column, protein_id_column]]
+
+    # Prepare metadata to merge
+    merge_columns = [*added_columns, sequence_column, protein_id_column]
+    metadata_to_add = adata_obs[merge_columns].drop_duplicates()
+
+    # Merge on sequence and protein ID
+    merge_keys = [sequence_column, protein_id_column]
+    merged_df = aggregated_df.merge(metadata_to_add, left_on=merge_keys, right_on=merge_keys, how="left")
+
+    # Recreate index as composite ID
+    merged_df.index = _create_peptide_group_id(merged_df[sequence_column], merged_df[protein_id_column])
+    merged_df.index = merged_df.index.astype(str)
+
+    return merged_df
+
+
+def _create_anndata_from_aggregated(
+    aggregated_df: pd.DataFrame,
+    original_adata_var: pd.DataFrame,
+    sequence_column: str,
+    protein_id_column: str,
+    added_columns: list[str] | None,
+) -> ad.AnnData:
+    """Construct AnnData object from aggregated peptide data.
+
+    Parameters
+    ----------
+    aggregated_df : pd.DataFrame
+        Aggregated quantification data with metadata
+    original_adata_var : pd.DataFrame
+        Original AnnData.var (sample metadata)
+    sequence_column : str
+        Column name for peptide sequences
+    protein_id_column : str
+        Column name for protein identifiers
+    added_columns : list[str] | None
+        Additional metadata columns included
+
+    Returns
+    -------
+    ad.AnnData
+        New AnnData object with aggregated peptide groups
+    """
+    # Determine variable metadata columns
+    var_columns = [sequence_column, protein_id_column]
+    if added_columns is not None:
+        var_columns = pd.Series(added_columns + var_columns).unique().tolist()
+
+    # Extract variable metadata
+    var_metadata = aggregated_df.loc[:, var_columns]
+
+    # Extract quantification matrix and transpose back to samples * peptides
+    quant_matrix = aggregated_df.drop(columns=var_columns).T
+
+    # Create AnnData object
+    return_adata = ad.AnnData(X=quant_matrix)
+
+    # Add sample metadata (obs) from original
+    return_adata.obs = original_adata_var.copy()
+
+    # Add peptide metadata (var)
+    return_adata.var = var_metadata.copy()
+
+    return return_adata
+
+
+def group_peptides(
+    adata: ad.AnnData,
+    sequence_column: str = "sequence",
+    protein_id_column: str = "proteins",
+    aggregation: str = "max",
+    added_columns: list[str] | None = None,
+) -> ad.AnnData:
+    """Aggregate peptide sequences by sequence and protein group.
+
+    Groups identical peptide sequences within the same protein group,
+    aggregating quantification values using the specified method. This is
+    useful for collapsing modified peptides or redundant identifications
+    to unique sequence-protein combinations.
+
+    The function:
+    1. Creates composite identifiers from sequence + protein ID
+    2. Aggregates quantification values for duplicate sequence-protein pairs
+    3. Removes duplicates within protein groups
+    4. Optionally merges additional metadata columns
+    5. Returns a new AnnData object with aggregated data
+
+    Parameters
+    ----------
+    adata : ad.AnnData
+        Input AnnData with peptides/precursors as variables (columns).
+        Must contain `sequence_column` and `protein_id_column` in `.var`.
+    sequence_column : str, optional
+        Column name in `.var` containing peptide sequences (default: "sequence")
+    protein_id_column : str, optional
+        Column name in `.var` containing protein identifiers (default: "proteins")
+    aggregation : str, optional
+        Aggregation method for duplicate entries. Common options: "max", "mean",
+        "median", "sum" (default: "max")
+    added_columns : list[str] | None, optional
+        Additional metadata columns from `.var` to include in output (default: None)
+
+    Returns
+    -------
+    ad.AnnData
+        New AnnData object with:
+        - `.X`: Aggregated quantification matrix (samples * peptide groups)
+        - `.obs`: Sample metadata from original (unchanged)
+        - `.var`: Peptide group metadata with sequence, protein ID, and any
+          additional columns specified
+
+    Raises
+    ------
+    TypeError
+        If `added_columns` is not a list
+
+    Examples
+    --------
+    Basic usage with default parameters:
+
+    .. code-block:: python
+
+        import anndata as ad
+        from alphasite.sequence_tools import group_peptides
+
+        # Load precursor data
+        adata = ad.read_h5ad("precursors.h5ad")
+
+        # Aggregate to unique sequence-protein combinations
+        adata_peptides = group_peptides(adata)
+
+    Include additional metadata:
+
+    .. code-block:: python
+
+        # Include gene names in output
+        adata_peptides = group_peptides(adata, added_columns=["genes", "kinase_status"])
+
+    Use mean aggregation instead of max:
+
+    .. code-block:: python
+
+        adata_peptides = group_peptides(adata, aggregation="mean")
+
+    Notes
+    -----
+    - The function transposes the input AnnData internally (peptides as rows)
+      for processing, then transposes back for output
+    - Composite identifiers use format: "{sequence}_IN_{protein_id}"
+    - Duplicates are removed after aggregation (same stripped sequence in
+      protein group)
+    - Missing values in metadata columns will be NaN after merge
+    """
+    # Validate input
+    if added_columns is not None and not isinstance(added_columns, list):
+        raise TypeError("added_columns must be a list")
+
+    # Step 1: Extract quantification data with metadata
+    data_df = _extract_quantification_data(adata, sequence_column, protein_id_column)
+
+    # Step 2: Aggregate by sequence and protein
+    aggregated_df = _aggregate_by_sequence_and_protein(data_df, sequence_column, protein_id_column, aggregation)
+
+    # Step 3: Add additional metadata if requested
+    if added_columns is not None:
+        adata_t = adata.T.copy()
+        aggregated_df = _add_metadata_columns(
+            aggregated_df,
+            adata_t.obs,
+            sequence_column,
+            protein_id_column,
+            added_columns,
+        )
+
+    # Step 4: Create output AnnData object
+    return _create_anndata_from_aggregated(
+        aggregated_df,
+        adata.var,
+        sequence_column,
+        protein_id_column,
+        added_columns,
+    )

--- a/src/alphapepttools/io/peptide_level.py
+++ b/src/alphapepttools/io/peptide_level.py
@@ -1,6 +1,8 @@
 import anndata as ad
 import pandas as pd
 
+import alphapepttools as apt
+
 
 def _create_peptide_group_id(sequence: pd.Series, protein_id: pd.Series, separator: str = "_IN_") -> pd.Series:
     """Create unique identifier by concatenating sequence and protein ID.
@@ -163,7 +165,7 @@ def _add_metadata_columns(
 
 def _create_anndata_from_aggregated(
     aggregated_df: pd.DataFrame,
-    original_adata_var: pd.DataFrame,
+    original_adata: ad.AnnData,
     sequence_column: str,
     protein_id_column: str,
     added_columns: list[str] | None,
@@ -174,8 +176,8 @@ def _create_anndata_from_aggregated(
     ----------
     aggregated_df : pd.DataFrame
         Aggregated quantification data with metadata
-    original_adata_var : pd.DataFrame
-        Original AnnData.var (sample metadata)
+    original_adata : ad.AnnData
+        Original AnnData object
     sequence_column : str
         Column name for peptide sequences
     protein_id_column : str
@@ -199,16 +201,14 @@ def _create_anndata_from_aggregated(
     # Extract quantification matrix and transpose back to samples * peptides
     quant_matrix = aggregated_df.drop(columns=var_columns).T
 
-    # Create AnnData object
+    # Create AnnData object with basic index information
     return_adata = ad.AnnData(X=quant_matrix)
 
-    # Add sample metadata (obs) from original
-    return_adata.obs = original_adata_var.copy()
+    # Use add_metadata to properly add sample metadata from original
+    return_adata = apt.pp.add_metadata(return_adata, original_adata.obs, axis=0)
 
-    # Add peptide metadata (var)
-    return_adata.var = var_metadata.copy()
-
-    return return_adata
+    # Use add_metadata to properly add peptide metadata
+    return apt.pp.add_metadata(return_adata, var_metadata, axis=1)
 
 
 def group_peptides(
@@ -322,7 +322,7 @@ def group_peptides(
     # Step 4: Create output AnnData object
     return _create_anndata_from_aggregated(
         aggregated_df,
-        adata.var,
+        adata,
         sequence_column,
         protein_id_column,
         added_columns,

--- a/tests/io/test_peptide_level.py
+++ b/tests/io/test_peptide_level.py
@@ -50,27 +50,27 @@ def expected_peptide_adata():
     """Create expected peptide-level AnnData after aggregation.
 
     Expected result after max aggregation:
-    - 2 peptides: PEPTIDEK_IN_P1;P1-1, DIPEPTKEK_IN_P2
-    - sample_1: [100, 3] (max of [10, 100] and max of [3])
-    - sample_2: [100, nan] (max of [100, 30] and nan)
+    - 2 peptides: DIPEPTKEK_IN_P2, PEPTIDEK_IN_P1;P1-1 (alphabetical order)
+    - sample_1: [3, 100] (max of [3] for DIPEPTKEK, max of [10, 100] for PEPTIDEK)
+    - sample_2: [nan, 100] (nan for DIPEPTKEK, max of [100, 30] for PEPTIDEK)
     """
-    # Expected index format: sequence_IN_protein
-    peptide_indices = ["PEPTIDEK_IN_P1;P1-1", "DIPEPTKEK_IN_P2"]
+    # Expected index format: sequence_IN_protein (alphabetical order)
+    peptide_indices = ["DIPEPTKEK_IN_P2", "PEPTIDEK_IN_P1;P1-1"]
 
-    # Quantification matrix after max aggregation
+    # Quantification matrix after max aggregation (matching alphabetical order)
     X = np.array(
         [
-            [100.0, 3.0],  # sample_1
-            [100.0, np.nan],  # sample_2
+            [3.0, 100.0],  # sample_1: DIPEPTKEK then PEPTIDEK
+            [np.nan, 100.0],  # sample_2: DIPEPTKEK then PEPTIDEK
         ]
     )
 
     # Sample metadata (unchanged from precursor level)
     obs = pd.DataFrame({"cell_type": ["T1", "T1"], "treatment": ["A", "B"]}, index=["sample_1", "sample_2"])
 
-    # Peptide metadata
+    # Peptide metadata (matching alphabetical order)
     var = pd.DataFrame(
-        {"genes": ["G1", "G2"], "sequence": ["PEPTIDEK", "DIPEPTKEK"], "proteins": ["P1;P1-1", "P2"]},
+        {"genes": ["G2", "G1"], "sequence": ["DIPEPTKEK", "PEPTIDEK"], "proteins": ["P2", "P1;P1-1"]},
         index=peptide_indices,
     )
 
@@ -126,27 +126,27 @@ def expected_peptide_adata_median():
     """Create expected peptide-level AnnData after median aggregation.
 
     Expected result after median aggregation:
-    - 2 peptides: PEPTIDEK_IN_P1;P1-1, DIPEPTKEK_IN_P2
-    - sample_1: [55, 3] (median of [10, 100] = 55, median of [3] = 3)
-    - sample_2: [65, nan] (median of [100, 30] = 65, median of [nan, nan] = nan)
+    - 2 peptides: DIPEPTKEK_IN_P2, PEPTIDEK_IN_P1;P1-1 (alphabetical order)
+    - sample_1: [3, 55] (median of [3] for DIPEPTKEK, median of [10, 100] for PEPTIDEK)
+    - sample_2: [nan, 65] (nan for DIPEPTKEK, median of [100, 30] for PEPTIDEK)
     """
-    # Expected index format: sequence_IN_protein
-    peptide_indices = ["PEPTIDEK_IN_P1;P1-1", "DIPEPTKEK_IN_P2"]
+    # Expected index format: sequence_IN_protein (alphabetical order)
+    peptide_indices = ["DIPEPTKEK_IN_P2", "PEPTIDEK_IN_P1;P1-1"]
 
-    # Quantification matrix after median aggregation
+    # Quantification matrix after median aggregation (matching alphabetical order)
     X = np.array(
         [
-            [55.0, 3.0],  # sample_1: median([10, 100]) = 55, median([3]) = 3
-            [65.0, np.nan],  # sample_2: median([100, 30]) = 65, median([nan, nan]) = nan
+            [3.0, 55.0],  # sample_1: DIPEPTKEK then PEPTIDEK
+            [np.nan, 65.0],  # sample_2: DIPEPTKEK then PEPTIDEK
         ]
     )
 
     # Sample metadata (unchanged from precursor level)
     obs = pd.DataFrame({"cell_type": ["T1", "T1"], "treatment": ["A", "B"]}, index=["sample_1", "sample_2"])
 
-    # Peptide metadata
+    # Peptide metadata (matching alphabetical order)
     var = pd.DataFrame(
-        {"genes": ["G1", "G2"], "sequence": ["PEPTIDEK", "DIPEPTKEK"], "proteins": ["P1;P1-1", "P2"]},
+        {"genes": ["G2", "G1"], "sequence": ["DIPEPTKEK", "PEPTIDEK"], "proteins": ["P2", "P1;P1-1"]},
         index=peptide_indices,
     )
 

--- a/tests/io/test_peptide_level.py
+++ b/tests/io/test_peptide_level.py
@@ -1,0 +1,207 @@
+"""Tests for peptide-level aggregation functions."""
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def precursor_adata():
+    """Create mock precursor-level AnnData for testing.
+
+    Creates 4 precursors that aggregate to 2 peptides:
+    - PEPTIDEK3 and PEPT(Mod1)IDEK2 � both strip to PEPTIDEK, protein P1;P1-1, gene G1
+    - DIPEPTKEK2 and DIPE(Mod2)PTKEK3 � both strip to DIPEPTKEK, protein P2, gene G2
+
+    Quantification values:
+    - sample_1: [10, 100, 3, nan] � after max aggregation: [100, 3]
+    - sample_2: [100, 30, nan, nan] � after max aggregation: [100, nan]
+    """
+    # Define precursor names (with charge states and modifications)
+    precursor_names = ["PEPTIDEK3", "PEPT(Mod1)IDEK2", "DIPEPTKEK2", "DIPE(Mod2)PTKEK3"]
+
+    # Quantification matrix: samples � precursors
+    X = np.array(
+        [
+            [10.0, 100.0, 3.0, np.nan],  # sample_1
+            [100.0, 30.0, np.nan, np.nan],  # sample_2
+        ]
+    )
+
+    # Sample metadata (obs)
+    obs = pd.DataFrame({"cell_type": ["T1", "T1"], "treatment": ["A", "B"]}, index=["sample_1", "sample_2"])
+
+    # Precursor metadata (var)
+    var = pd.DataFrame(
+        {
+            "sequence": ["PEPTIDEK", "PEPTIDEK", "DIPEPTKEK", "DIPEPTKEK"],
+            "proteins": ["P1;P1-1", "P1;P1-1", "P2", "P2"],
+            "genes": ["G1", "G1", "G2", "G2"],
+        },
+        index=precursor_names,
+    )
+
+    return ad.AnnData(X=X, obs=obs, var=var)
+
+
+@pytest.fixture
+def expected_peptide_adata():
+    """Create expected peptide-level AnnData after aggregation.
+
+    Expected result after max aggregation:
+    - 2 peptides: PEPTIDEK_IN_P1;P1-1, DIPEPTKEK_IN_P2
+    - sample_1: [100, 3] (max of [10, 100] and max of [3])
+    - sample_2: [100, nan] (max of [100, 30] and nan)
+    """
+    # Expected index format: sequence_IN_protein
+    peptide_indices = ["PEPTIDEK_IN_P1;P1-1", "DIPEPTKEK_IN_P2"]
+
+    # Quantification matrix after max aggregation
+    X = np.array(
+        [
+            [100.0, 3.0],  # sample_1
+            [100.0, np.nan],  # sample_2
+        ]
+    )
+
+    # Sample metadata (unchanged from precursor level)
+    obs = pd.DataFrame({"cell_type": ["T1", "T1"], "treatment": ["A", "B"]}, index=["sample_1", "sample_2"])
+
+    # Peptide metadata
+    var = pd.DataFrame(
+        {"genes": ["G1", "G2"], "sequence": ["PEPTIDEK", "DIPEPTKEK"], "proteins": ["P1;P1-1", "P2"]},
+        index=peptide_indices,
+    )
+
+    return ad.AnnData(X=X, obs=obs, var=var)
+
+
+def test_group_peptides_basic(precursor_adata, expected_peptide_adata):
+    """Test basic peptide grouping with max aggregation."""
+    from alphapepttools.io.peptide_level import group_peptides
+
+    result = group_peptides(
+        precursor_adata,
+        sequence_column="sequence",
+        protein_id_column="proteins",
+        aggregation="max",
+        added_columns=["genes"],
+    )
+
+    # Check X matrix equality (using allclose for NaN handling)
+    np.testing.assert_array_equal(result.X, expected_peptide_adata.X)
+
+    # Check obs dataframe equality
+    pd.testing.assert_frame_equal(result.obs, expected_peptide_adata.obs)
+
+    # Check var dataframe equality (sorting columns to ensure order matches)
+    result_var_sorted = result.var.sort_index(axis=1)
+    expected_var_sorted = expected_peptide_adata.var.sort_index(axis=1)
+    pd.testing.assert_frame_equal(result_var_sorted, expected_var_sorted)
+
+
+def test_group_peptides_without_added_columns(precursor_adata):
+    """Test peptide grouping without additional metadata columns."""
+    from alphapepttools.io.peptide_level import group_peptides
+
+    result = group_peptides(
+        precursor_adata, sequence_column="sequence", protein_id_column="proteins", aggregation="max", added_columns=None
+    )
+
+    # Should still have sequence and proteins columns
+    assert "sequence" in result.var.columns
+    assert "proteins" in result.var.columns
+
+    # Should NOT have genes column
+    assert "genes" not in result.var.columns
+
+    # Check dimensions
+    assert result.n_obs == 2  # noqa: PLR2004
+    assert result.n_vars == 2  # noqa: PLR2004
+
+
+@pytest.fixture
+def expected_peptide_adata_median():
+    """Create expected peptide-level AnnData after median aggregation.
+
+    Expected result after median aggregation:
+    - 2 peptides: PEPTIDEK_IN_P1;P1-1, DIPEPTKEK_IN_P2
+    - sample_1: [55, 3] (median of [10, 100] = 55, median of [3] = 3)
+    - sample_2: [65, nan] (median of [100, 30] = 65, median of [nan, nan] = nan)
+    """
+    # Expected index format: sequence_IN_protein
+    peptide_indices = ["PEPTIDEK_IN_P1;P1-1", "DIPEPTKEK_IN_P2"]
+
+    # Quantification matrix after median aggregation
+    X = np.array(
+        [
+            [55.0, 3.0],  # sample_1: median([10, 100]) = 55, median([3]) = 3
+            [65.0, np.nan],  # sample_2: median([100, 30]) = 65, median([nan, nan]) = nan
+        ]
+    )
+
+    # Sample metadata (unchanged from precursor level)
+    obs = pd.DataFrame({"cell_type": ["T1", "T1"], "treatment": ["A", "B"]}, index=["sample_1", "sample_2"])
+
+    # Peptide metadata
+    var = pd.DataFrame(
+        {"genes": ["G1", "G2"], "sequence": ["PEPTIDEK", "DIPEPTKEK"], "proteins": ["P1;P1-1", "P2"]},
+        index=peptide_indices,
+    )
+
+    return ad.AnnData(X=X, obs=obs, var=var)
+
+
+def test_group_peptides_median_aggregation(precursor_adata, expected_peptide_adata_median):
+    """Test peptide grouping with median aggregation."""
+    from alphapepttools.io.peptide_level import group_peptides
+
+    result = group_peptides(
+        precursor_adata,
+        sequence_column="sequence",
+        protein_id_column="proteins",
+        aggregation="median",
+        added_columns=["genes"],
+    )
+
+    # Check X matrix equality
+    np.testing.assert_array_equal(result.X, expected_peptide_adata_median.X)
+
+    # Check obs dataframe equality
+    pd.testing.assert_frame_equal(result.obs, expected_peptide_adata_median.obs)
+
+    # Check var dataframe equality (sorting columns to ensure order matches)
+    result_var_sorted = result.var.sort_index(axis=1)
+    expected_var_sorted = expected_peptide_adata_median.var.sort_index(axis=1)
+    pd.testing.assert_frame_equal(result_var_sorted, expected_var_sorted)
+
+
+def test_group_peptides_invalid_added_columns(precursor_adata):
+    """Test that invalid added_columns type raises TypeError."""
+    from alphapepttools.io.peptide_level import group_peptides
+
+    with pytest.raises(TypeError, match="added_columns must be a list"):
+        group_peptides(
+            precursor_adata,
+            added_columns="genes",  # Should be a list, not a string
+        )
+
+
+def test_group_peptides_preserves_index_format(precursor_adata):
+    """Test that output index follows expected format: sequence_IN_protein."""
+    from alphapepttools.io.peptide_level import group_peptides
+
+    result = group_peptides(
+        precursor_adata,
+        sequence_column="sequence",
+        protein_id_column="proteins",
+        aggregation="max",
+        added_columns=["genes"],
+    )
+
+    # Check index format
+    expected_indices = ["PEPTIDEK_IN_P1;P1-1", "DIPEPTKEK_IN_P2"]
+
+    for expected_idx in expected_indices:
+        assert expected_idx in result.var_names, f"Expected index {expected_idx} not found"


### PR DESCRIPTION
### Reason for the PR
In the context of peptidomics, precursors are often required to be aggregated into peptides to evaluate miscleavages, sequence coverage, and to bridge the conceptual gap between precursors as MS-proteomics analytes and gene sequences in the analysis. This PR implements a `peptide_level.py` module with a `group_peptides()` function, which transforms precursor-level AnnData objects into peptide-level AnnData objects with a specified aggregation function (default to max). 

### Aggregation function
the default max aggregation is chosen with rare PTMs in mind: if a precursor exists in two states, one bare precursor and one bearing a rare PTM, median and mean aggregation would severly underestimate the overall abundance. Taking the max-value as the peptide value is an attempt to accurately reflect the baseline abundance of the peptide. 

### Discussion points
Sum aggregation may be equally appropriate, however normalization may lead to overestimation of total peptide abundance. 