### PR TITLE
FEATURE_LEVEL_CONFIG in reader_columns.py has a mistaken singular key

### DIFF
--- a/src/alphapepttools/io/reader_columns.py
+++ b/src/alphapepttools/io/reader_columns.py
@@ -11,7 +11,7 @@ FEATURE_LEVEL_CONFIG = {
         "feature_id_column": PsmDfCols.PROTEINS,
         "sample_id_column": PsmDfCols.RAW_NAME,
     },
-    "precursor": {
+    "precursors": {
         "intensity_column": PsmDfCols.PRECURSOR_INTENSITY,
         "feature_id_column": PsmDfCols.PRECURSOR_ID,
         "sample_id_column": PsmDfCols.RAW_NAME,


### PR DESCRIPTION
fix typo in key which breaks the retrieval of precursor level columns by `read_psm_table`: when calling `read_psm_table` wtih level="precursors" and no other column names specified the function crashes with `ValueError: intensity_column is required but not provided and no default found for reader_type='diann' and level='precursors'.` --> that's because the FEATURE_LEVEL_CONFIG in `reader_columns.py` has the singular "precursor" and not "precursors", which this PR fixes.