### PR TITLE
Fix/combat

### DIFF
--- a/src/alphapepttools/pp/batch_correction.py
+++ b/src/alphapepttools/pp/batch_correction.py
@@ -134,7 +134,7 @@ def scanpy_pycombat(
         Name of the batch feature in obs, the variation associated with this feature will be corrected.
         Missing values in this column will be replaced by one single "NA" batch
     covariates
-        Columns in `adata.obs` indicating real biological variation. Variation associated with these columns will be retained.
+        Columns in `adata.obs` indicating biological variation. Variation associated with these columns will be retained.
     layer
         Name of the layer to batch correct. If None (default), the attribute adata.X is used
     copy

--- a/src/alphapepttools/pp/batch_correction.py
+++ b/src/alphapepttools/pp/batch_correction.py
@@ -115,7 +115,7 @@ def drop_singleton_batches(
 
 
 def scanpy_pycombat(
-    adata: ad.AnnData, batch: str, covariates: None | list[str], layer: str | None = None, *, copy: bool = False
+    adata: ad.AnnData, batch: str, covariates: None | list[str] = None, layer: str | None = None, *, copy: bool = False
 ) -> ad.AnnData:
     """Correct batch effects using the ComBat method :cite:`Johnson.2007`.
 

--- a/src/alphapepttools/pp/batch_correction.py
+++ b/src/alphapepttools/pp/batch_correction.py
@@ -114,7 +114,9 @@ def drop_singleton_batches(
     return adata
 
 
-def scanpy_pycombat(adata: ad.AnnData, batch: str, layer: str | None = None, *, copy: bool = False) -> ad.AnnData:
+def scanpy_pycombat(
+    adata: ad.AnnData, batch: str, covariates: None | list[str], layer: str | None = None, *, copy: bool = False
+) -> ad.AnnData:
     """Correct batch effects using the ComBat method :cite:`Johnson.2007`.
 
     Applies empirical Bayes batch correction to remove systematic
@@ -131,6 +133,8 @@ def scanpy_pycombat(adata: ad.AnnData, batch: str, layer: str | None = None, *, 
     batch
         Name of the batch feature in obs, the variation associated with this feature will be corrected.
         Missing values in this column will be replaced by one single "NA" batch
+    covariates
+        Columns in `adata.obs` indicating real biological variation. Variation associated with these columns will be retained.
     layer
         Name of the layer to batch correct. If None (default), the attribute adata.X is used
     copy
@@ -202,7 +206,7 @@ def scanpy_pycombat(adata: ad.AnnData, batch: str, layer: str | None = None, *, 
         raise ValueError(" scanpy_pycombat: At least one batch contains only one single sample.")
 
     # Adjust to scanpy API
-    batch_corrected_result = scanpy.pp.combat(adata, key=batch, inplace=False)
+    batch_corrected_result = scanpy.pp.combat(adata, key=batch, covariates=covariates, inplace=False)
 
     if layer is None:
         adata.X = batch_corrected_result

--- a/tests/pp/test_batch_correction.py
+++ b/tests/pp/test_batch_correction.py
@@ -61,6 +61,7 @@ def test_convert_na_to_batch():
 
 @pytest.mark.parametrize("copy", [False, True])
 @pytest.mark.parametrize("layer", [False, True])
+@pytest.mark.parametrize("covariates", [None])
 @pytest.mark.parametrize(
     ("datatype"),
     [
@@ -70,7 +71,9 @@ def test_convert_na_to_batch():
         ("complex"),
     ],
 )
-def test_scanpy_pycombat(datatype, pycombat_test_data_simple, pycombat_test_data_complex, layer: str, *, copy: bool):
+def test_scanpy_pycombat(
+    datatype, pycombat_test_data_simple, pycombat_test_data_complex, covariates, layer: str, *, copy: bool
+):
     """
     Test the scanpy_pycombat function with various scenarios.
     """
@@ -87,10 +90,10 @@ def test_scanpy_pycombat(datatype, pycombat_test_data_simple, pycombat_test_data
 
     # Compute expected results
     expected_adata = adata.copy()
-    scanpy.pp.combat(expected_adata, key="batch", inplace=True)
+    scanpy.pp.combat(expected_adata, key="batch", covariates=covariates, inplace=True)
 
     # Get comparison data from wrapper
-    result = scanpy_pycombat(adata, batch="batch", layer=layer, copy=copy)
+    result = scanpy_pycombat(adata, batch="batch", covariates=covariates, layer=layer, copy=copy)
 
     if copy:
         assert isinstance(result, ad.AnnData)


### PR DESCRIPTION
Expose `covariates` argument in combat function. Needed to correctly retain biological variation. 