### PR TITLE
fix failing unit test on pre-release: 

### DIFF
--- a/tests/pp/test_norm.py
+++ b/tests/pp/test_norm.py
@@ -115,7 +115,7 @@ class TestNormalizeFunction:
 
         assert np.isclose(adata.X, expected_arrays[strategy], atol=1e-6, equal_nan=True).all()
         assert len(adata.obs.columns) == 0
-        assert len(adata.layers) == 0
+        assert [k for k in adata.layers if k is not None] == []
 
     @pytest.mark.parametrize("strategy", ["total_mean", "total_median"])
     @pytest.mark.parametrize("data_type", ["all_equal", "different", "nan"])


### PR DESCRIPTION
### Reason for the fix:

pre-release anndata reimplements .X as a layer with the key None. the previous version of this test failed in "PRE-RELEASE DEPENDENCIES Python 3.14" because the len of layers was no longer 0 but 1 after explicitly assigning X = X.copy(). 

### Fix:
The test now asserts whether the list from adata.layers is empty, not counting the None layer.