### PR TITLE
Adjust fonts and lines

### DIFF
--- a/src/alphapepttools/pl/defaults.py
+++ b/src/alphapepttools/pl/defaults.py
@@ -15,15 +15,15 @@ class PlotSettings:
     Attributes
     ----------
     font_sizes
-        Font size presets with keys 'small' (8pt), 'medium' (10pt), 'large' (12pt)
+        Font size presets with keys 'small' (5pt), 'medium' (6pt), 'large' (7pt)
     axes
-        Axes-specific settings for title_size, label_size, and tick_size (all 10pt)
+        Axes-specific settings for title_size (7pt), label_size (6pt), tick_size (6pt)
     legend
-        Legend settings for font_size and title_size (both 10pt)
+        Legend settings for font_size and title_size (both 6pt)
     marker_sizes
         Marker size presets with keys 'small' (5), 'medium' (10), 'large' (15)
     linewidths
-        Line width presets with keys 'small' (0.25), 'medium' (0.5), 'large' (1.25)
+        Line width presets with keys 'small' (0.17), 'medium' (0.33), 'large' (0.83)
     highlight_colors
         Color presets for highlighting with keys 'high' (#9ecae1), 'low' (#fdae6b),
         'general' (#5ec962)
@@ -51,7 +51,7 @@ class PlotSettings:
         from alphapepttools.pl import defaults
 
         # Access current settings
-        print(defaults.plot_settings.font_sizes["large"])  # 12
+        print(defaults.plot_settings.font_sizes["large"])  # 7
 
     Export settings for inspection or serialization:
 
@@ -82,20 +82,20 @@ class PlotSettings:
 
     def __init__(self):
         self.font_sizes = {
-            "small": 8,
-            "medium": 10,
-            "large": 12,
+            "small": 5,
+            "medium": 6,
+            "large": 7,
         }
 
         self.axes = {
-            "title_size": 10,
-            "label_size": 10,
-            "tick_size": 10,
+            "title_size": 7,
+            "label_size": 6,
+            "tick_size": 6,
         }
 
         self.legend = {
-            "font_size": 10,
-            "title_size": 10,
+            "font_size": 6,
+            "title_size": 6,
         }
 
         self.marker_sizes = {
@@ -105,9 +105,9 @@ class PlotSettings:
         }
 
         self.linewidths = {
-            "small": 0.25,
-            "medium": 0.5,
-            "large": 1.25,
+            "small": 0.17,
+            "medium": 0.33,
+            "large": 0.83,
         }
 
         self.highlight_colors = {
@@ -155,7 +155,7 @@ class PlotSettings:
             from alphapepttools.pl import defaults
 
             config = defaults.plot_settings.to_dict()
-            print(config["font_sizes"])  # {'small': 8, 'medium': 10, 'large': 12}
+            print(config["font_sizes"])  # {'small': 5, 'medium': 6, 'large': 7}
 
         Use settings for custom configuration:
 

--- a/src/alphapepttools/pl/figure.py
+++ b/src/alphapepttools/pl/figure.py
@@ -639,6 +639,14 @@ def create_figure(
             "svg.fonttype": "none",
             "pdf.fonttype": 42,
             "ps.fonttype": 42,
+            "axes.linewidth": config["linewidths"]["small"],
+            "grid.linewidth": config["linewidths"]["small"],
+            "xtick.major.width": config["linewidths"]["small"],
+            "ytick.major.width": config["linewidths"]["small"],
+            "xtick.minor.width": config["linewidths"]["small"],
+            "ytick.minor.width": config["linewidths"]["small"],
+            "lines.linewidth": config["linewidths"]["medium"],
+            "patch.linewidth": config["linewidths"]["medium"],
         }
     )
 

--- a/src/alphapepttools/pl/figure.py
+++ b/src/alphapepttools/pl/figure.py
@@ -639,7 +639,7 @@ def create_figure(
             "svg.fonttype": "none",
             "pdf.fonttype": 42,
             "ps.fonttype": 42,
-            "axes.linewidth": config["linewidths"]["small"],
+            "axes.linewidth": config["linewidths"]["medium"],
             "grid.linewidth": config["linewidths"]["small"],
             "xtick.major.width": config["linewidths"]["small"],
             "ytick.major.width": config["linewidths"]["small"],

--- a/src/alphapepttools/pl/plots.py
+++ b/src/alphapepttools/pl/plots.py
@@ -167,7 +167,7 @@ def add_lines(
     linestyle
         Line style (e.g., `"--"`, `"-"`, `":"`)
     linewidth
-        Line width, defaults to `config["linewidths"]["medium"]`
+        Line width, defaults to `config["linewidths"]["large"]`
     line_kwargs
         Additional matplotlib line arguments. Note: explicit color, linestyle,
         and linewidth parameters take precedence
@@ -196,7 +196,7 @@ def add_lines(
     line_func = ax.axvline if linetype == "vline" else ax.axhline
 
     if linewidth is None:
-        linewidth = config["linewidths"]["medium"]
+        linewidth = config["linewidths"]["large"]
 
     if not isinstance(intercepts, (list | float | int)):
         raise TypeError("intercepts must be a float, int, or list of floats/ints")

--- a/src/alphapepttools/pl/plots.py
+++ b/src/alphapepttools/pl/plots.py
@@ -146,7 +146,7 @@ def add_lines(
     linetype: str = "vline",
     color: str = "black",
     linestyle: str = "--",
-    linewidth: float | None = None,
+    linewidth: float | None = config["linewidths"]["large"],
     line_kwargs: dict | None = None,
 ) -> None:
     """Add vertical or horizontal reference lines to a plot
@@ -194,9 +194,6 @@ def add_lines(
     if linetype not in ["vline", "hline"]:
         raise ValueError("linetype must be 'vline' or 'hline'")
     line_func = ax.axvline if linetype == "vline" else ax.axhline
-
-    if linewidth is None:
-        linewidth = config["linewidths"]["large"]
 
     if not isinstance(intercepts, (list | float | int)):
         raise TypeError("intercepts must be a float, int, or list of floats/ints")

--- a/src/alphapepttools/pl/plots.py
+++ b/src/alphapepttools/pl/plots.py
@@ -146,7 +146,7 @@ def add_lines(
     linetype: str = "vline",
     color: str = "black",
     linestyle: str = "--",
-    linewidth: float = 1,
+    linewidth: float | None = None,
     line_kwargs: dict | None = None,
 ) -> None:
     """Add vertical or horizontal reference lines to a plot
@@ -194,6 +194,9 @@ def add_lines(
     if linetype not in ["vline", "hline"]:
         raise ValueError("linetype must be 'vline' or 'hline'")
     line_func = ax.axvline if linetype == "vline" else ax.axhline
+
+    if linewidth is None:
+        linewidth = config["linewidths"]["medium"]
 
     if not isinstance(intercepts, (list | float | int)):
         raise TypeError("intercepts must be a float, int, or list of floats/ints")


### PR DESCRIPTION
### Minor adjustment to create more paper-ready figures:

Recap: `create_figure` comes with Nature-style presets for the `figsize` argument: when calling `create_figure(figsize=("1", "1"))`, it creates a panel measured out to one column of a typical Nature-style figure panel.

### What was fixed:

Considering these presets, default small, medium and large font sizes and line widths were too large, clashing with the intended appearance on pages & in print. This PR adjusts font sizes and linewidths and fixes some inconsistencies where dimensions were not properly retrieved from the `defaults.py` module.