### PR TITLE
Avoid eager package imports

### DIFF
--- a/src/alphapepttools/__init__.py
+++ b/src/alphapepttools/__init__.py
@@ -1,5 +1,17 @@
-from . import data, io, metrics, pl, pp, tl
+from importlib import import_module as _import_module
+from types import ModuleType as _ModuleType
 
 __all__: list[str] = ["data", "io", "metrics", "pl", "pp", "tl"]
 
 __version__ = "0.2.1-dev0"
+
+
+def __getattr__(name: str) -> _ModuleType:
+    if name not in __all__:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    return _import_module(f".{name}", __name__)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/src/alphapepttools/pl/__init__.py
+++ b/src/alphapepttools/pl/__init__.py
@@ -1,26 +1,7 @@
+from importlib import import_module as _import_module
+
 from .colors import BaseColormaps, BaseColors, BasePalettes, MappedColormaps, get_color_mapping, show_rgba_color_list
 from .figure import create_figure, label_axes, save_figure
-from .plots import (
-    PlotConfig,
-    Plots,  # Kept here for backward compatibility, using Plots raises and alerts the user about the deprecation and how to upgrade.
-    add_legend_to_axes,
-    add_legend_to_axes_from_patches,
-    add_lines,
-    barplot,
-    boxplot,
-    histogram,
-    label_plot,
-    layered_plot,
-    make_scatter_config,
-    plot_pca,
-    plot_pca_loadings,
-    plot_pca_loadings_2d,
-    rank_median_plot,
-    scatter,
-    scree_plot,
-    violinplot,
-    volcano,
-)
 
 __all__ = [
     "BaseColormaps",
@@ -52,3 +33,21 @@ __all__ = [
     "violinplot",
     "volcano",
 ]
+
+_PLOT_EXPORTS = frozenset(name for name in __all__ if name not in globals())
+
+
+def __getattr__(name: str) -> object:
+    if name == "plots":
+        return _import_module(".plots", __name__)
+
+    if name not in _PLOT_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    value = getattr(_import_module(".plots", __name__), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__) | {"plots"})

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -1,0 +1,22 @@
+import subprocess
+import sys
+
+_LAZY_IMPORT_CHECK = """
+import sys
+import alphapepttools
+
+assert {f"alphapepttools.{name}" for name in alphapepttools.__all__}.isdisjoint(sys.modules)
+
+pl = alphapepttools.pl
+from alphapepttools.pl.figure import AxisManager
+
+assert {"anndata", "scanpy", "alphapepttools.pl.plots"}.isdisjoint(sys.modules)
+
+barplot = pl.barplot
+assert barplot is pl.barplot
+assert pl.plots is sys.modules["alphapepttools.pl.plots"]
+"""
+
+
+def test_lightweight_imports_are_lazy() -> None:
+    subprocess.run([sys.executable, "-c", _LAZY_IMPORT_CHECK], check=True)  # noqa: S603


### PR DESCRIPTION
## Summary

Importing `alphapepttools` no longer eagerly imports every public submodule, and importing `alphapepttools.pl` no longer loads the heavy plotting implementation until it is accessed. Existing entry points such as `alphapepttools.io`, `alphapepttools.pl.scatter`, and `from alphapepttools import tl` remain available through lazy attribute resolution.

The lazy loaders cache resolved modules and exports after first access, _while dependency errors surface only when the relevant functionality is requested_.
## Dependency boundary

This PR changes import-time behavior without changing the package's declared installation dependencies. Environments that intentionally exclude the analysis dependency stack can still use lightweight plotting primitives, such as `from alphapepttools.pl.figure import AxisManager`, without importing AnnData or Scanpy. Data-aware exports from `alphapepttools.pl.plots` continue to load their analysis dependencies when accessed.

## Implementation note

Lazy module attributes use the module-level `__getattr__` and `__dir__` hooks proposed in [PEP 562](https://peps.python.org/pep-0562/) and documented in the corresponding [Python data model documentation](https://docs.python.org/3/reference/datamodel.html#customizing-module-attribute-access).

This contribution was partially written by an LLM, but I reviewed the changes and this PR description myself. 