### PR TITLE
[actions] Add dependabot action

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,16 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    # Do not pull most recent updates to ensure that security issues get detected
+    # This only applies for version updates, i.e. security-relevant releases are immediately applied
+    cooldown:
+      default-days: 7
+    commit-message:
+      include: scope
+      prefix: "[dep]"


### PR DESCRIPTION
Use dependabot to automatically update GitHub actions. Sets a cooldown time of 7 days so that security-relevant bugs in newer action versions can get fixed before they get introduced into the package. 

Mirrors: https://github.com/MannLabs/dvp-io/pull/157

