### PR TITLE
[Doc] API consistency and `copy` vs. `inplace` usage

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -42,15 +42,18 @@ pip install -e ".[dev,test,doc]"
 
 ## Handling anndata objects
 
-The central data structure of `alphapepttools` is the `anndata.AnnData` object. All functions should be compatible with `anndata.AnnData`.
+The central data structure of `alphapepttools` is the `anndata.AnnData` object. All functions should be compatible with `anndata.AnnData`. We default to `inplace` modifications, i.e. functions should default to returning `None` and acting on passed `anndata.AnnData` objects directly. This behaviour is adapted from [`scanpy v1`](https://scanpy.readthedocs.io/en/stable/) and aims to maximize the compatibility of the interfaces.
 
-Functions that act on the omics data in the anndata object (typically in the `.pp` and `.tl` modules) should generally follow the following call signature
+### Acting on omics measurements
+
+Functions that act on the measurement data (`.X`, `.layers[...]`) in the anndata object (typically in the `.pp` and `.tl` modules) or change the object's shape (e.g. filtering operations) _MUST_ follow the following call signature
 
 ```python
-alphapepttools.pp.func(adata: ad.AnnData, ..., layer: str | None = None, copy: bool = False) -> None | ad.AnnData:
+alphapepttools.pp.func(adata: ad.AnnData, ..., *, layer: str | None = None, copy: bool = False) -> None | ad.AnnData:
 ...
 
-alphapepttools.tl.func(adata: ad.AnnData, ..., layer: str | None = None, copy: bool = False) -> None | ad.AnnData:
+alphapepttools.tl.func(adata: ad.AnnData, ..., *, layer: str | None = None, copy: bool = False) -> None | ad.AnnData:
+  ...
 
 ```
 
@@ -58,9 +61,7 @@ alphapepttools.tl.func(adata: ad.AnnData, ..., layer: str | None = None, copy: b
 
 **Modification inplace** Per default, the `anndata.AnnData` object is modified inplace (`copy=False`), this means that the current object is updated and the function returns `None`. If `copy=True`, an updated copy of the object is returned and the original object remains unchanged.
 
-This behaviour is adapted from [`scanpy`](https://scanpy.readthedocs.io/en/stable/) and aims to maximize the compatibility of the interfaces.
-
-### Examples
+#### Examples
 
 Default behaviour:
 
@@ -98,7 +99,30 @@ assert not np.array_equal(adata.X, adata_new.X)
 
 # The original anndata remains unchanged
 assert np.array_equal(adata.X, adata_original.X)
+```
 
+### Generating summary statistics from anndata object
+
+Functions that generate new summary statistics and do not act on the measurement layers `.X`/`.layers` (e.g. differential expression analysis results, summary metrics, etc.; typically in `.tl`, and `.metrics` module) _SHOULD_ store the data inplace in the anndata object. They _MAY_ also allow users to return the results as a `pandas.DataFrame` by exposing an `inplace` argument. They should follow this general call signature:
+
+```python
+alphapepttools.tl.func(adata: ad.AnnData, ..., *, layer: str | None = None, inplace: bool = True) -> None | pd.DataFrame:
+  ...
+
+alphapepttools.metrics.func(adata: ad.AnnData, ..., *, layer: str | None = None, inplace: bool = True) -> None | pd.DataFrame:
+  ...
+```
+
+In summary, the keyword `inplace` also determines if an anndata object is modified, but it determines if a result is added to a non-measurement layer slot in anndata (`.obs`, `.var`, `.obsm`, `.varm`, `.uns`) or if it is returned as dataframe.
+
+#### Examples
+
+```
+result = apt.tl.func(adata, ..., inplace=False)
+assert isinstance(result, pd.DataFrame)
+
+result = apt.tl.func(adata, ..., inplace=True)
+assert result is None
 ```
 
 ## Code-style

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -42,11 +42,11 @@ pip install -e ".[dev,test,doc]"
 
 ## Handling anndata objects
 
-The central data structure of `alphapepttools` is the `anndata.AnnData` object. All functions should be compatible with `anndata.AnnData`. We default to `inplace` modifications, i.e. functions should default to returning `None` and acting on passed `anndata.AnnData` objects directly. This behaviour is adapted from [`scanpy v1`](https://scanpy.readthedocs.io/en/stable/) and aims to maximize the compatibility of the interfaces.
+The central data structure of `alphapepttools` is the `anndata.AnnData` object. All functions should be compatible with `anndata.AnnData`. We default to `inplace` modifications, i.e., functions should default to returning `None` and acting directly on the passed `anndata.AnnData` object. This behaviour is adapted from [`scanpy v1`](https://scanpy.readthedocs.io/en/stable/) and aims to maximize the compatibility of the interfaces.
 
 ### Acting on omics measurements
 
-Functions that act on the measurement data (`.X`, `.layers[...]`) in the anndata object (typically in the `.pp` and `.tl` modules) or change the object's shape (e.g. filtering operations) _MUST_ follow the following call signature
+Functions that act on the measurement data (`.X`, `.layers[...]`) in the anndata object (typically in the `.pp` and `.tl` modules) or change the object's shape (e.g., filtering operations) _MUST_ use the following call signature:
 
 ```python
 alphapepttools.pp.func(adata: ad.AnnData, ..., *, layer: str | None = None, copy: bool = False) -> None | ad.AnnData:
@@ -103,7 +103,7 @@ assert np.array_equal(adata.X, adata_original.X)
 
 ### Generating summary statistics from anndata object
 
-Functions that generate new summary statistics and do not act on the measurement layers `.X`/`.layers` (e.g. differential expression analysis results, summary metrics, etc.; typically in `.tl`, and `.metrics` module) _SHOULD_ store the data inplace in the anndata object. They _MAY_ also allow users to return the results as a `pandas.DataFrame` by exposing an `inplace` argument. They should follow this general call signature:
+Functions that generate new summary statistics and do not act on the measurement layers `.X`/`.layers` (e.g., differential expression analysis results or summary metrics; typically in the `.tl` and `.metrics` modules) _SHOULD_ store the results inplace in the anndata object. They _MAY_ also allow users to return the results as a `pandas.DataFrame` by exposing an `inplace` argument. They should follow this general call signature:
 
 ```python
 alphapepttools.tl.func(adata: ad.AnnData, ..., *, layer: str | None = None, inplace: bool = True) -> None | pd.DataFrame:
@@ -113,11 +113,11 @@ alphapepttools.metrics.func(adata: ad.AnnData, ..., *, layer: str | None = None,
   ...
 ```
 
-In summary, the keyword `inplace` also determines if an anndata object is modified, but it determines if a result is added to a non-measurement layer slot in anndata (`.obs`, `.var`, `.obsm`, `.varm`, `.uns`) or if it is returned as dataframe.
+Similarly to the `copy` argument, the keyword `inplace` determines whether the anndata object is directly modified or not. `inplace` should always be used when the result is either added to a non-measurement slot of the anndata object (`.obs`, `.var`, `.obsm`, `.varm`, `.uns`) or returned as a `pandas.DataFrame`. In contrast, `copy` should be used when a measurement slot is modified.
 
 #### Examples
 
-```
+```python
 result = apt.tl.func(adata, ..., inplace=False)
 assert isinstance(result, pd.DataFrame)
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -42,7 +42,7 @@ pip install -e ".[dev,test,doc]"
 
 ## Handling anndata objects
 
-The central data structure of `alphapepttools` is the `anndata.AnnData` object. All functions should be compatible with `anndata.AnnData`. We default to `inplace` modifications, i.e., functions should default to returning `None` and acting directly on the passed `anndata.AnnData` object. This behaviour is adapted from [`scanpy v1`](https://scanpy.readthedocs.io/en/stable/) and aims to maximize the compatibility of the interfaces.
+The central data structure of `alphapepttools` is the `anndata.AnnData` object. All functions should be compatible with `anndata.AnnData`. We default to in-place modification, i.e., functions return `None` and act directly on the passed `anndata.AnnData` object. This behaviour is adapted from [`scanpy v1`](https://scanpy.readthedocs.io/en/stable/) and aims to maximize the compatibility of the interfaces.
 
 ### Acting on omics measurements
 
@@ -103,7 +103,7 @@ assert np.array_equal(adata.X, adata_original.X)
 
 ### Generating summary statistics from anndata object
 
-Functions that generate new summary statistics and do not act on the measurement layers `.X`/`.layers` (e.g., differential expression analysis results or summary metrics; typically in the `.tl` and `.metrics` modules) _SHOULD_ store the results inplace in the anndata object. They _MAY_ also allow users to return the results as a `pandas.DataFrame` by exposing an `inplace` argument. They should follow this general call signature:
+Functions that generate new summary statistics and do not act on the measurement layers `.X`/`.layers` (e.g., differential expression analysis results or summary metrics; typically in the `.tl` and `.metrics` modules) _SHOULD_ store the results in place in the anndata object. They _MAY_ additionally allow users to return the results as a `pandas.DataFrame` by exposing an `inplace` argument. Functions that expose `inplace` _MUST_ default it to `True` and use the following call signature:
 
 ```python
 alphapepttools.tl.func(adata: ad.AnnData, ..., *, layer: str | None = None, inplace: bool = True) -> None | pd.DataFrame:
@@ -113,15 +113,23 @@ alphapepttools.metrics.func(adata: ad.AnnData, ..., *, layer: str | None = None,
   ...
 ```
 
-Similarly to the `copy` argument, the keyword `inplace` determines whether the anndata object is directly modified or not. `inplace` should always be used when the result is either added to a non-measurement slot of the anndata object (`.obs`, `.var`, `.obsm`, `.varm`, `.uns`) or returned as a `pandas.DataFrame`. In contrast, `copy` should be used when a measurement slot is modified.
+With `inplace=True` (default), the result is written to a non-measurement slot of the anndata object (`.obs`, `.var`, `.obsm`, `.varm`, `.uns`) and the function returns `None`; with `inplace=False`, the result is returned as a `pandas.DataFrame` and the anndata object is left unchanged.
+
+The two outcomes are exclusive: a function _MUST NOT_ both store the result in the anndata object and return it.
+
+### `copy` vs. `inplace`
+
+Like `copy`, the keyword `inplace` determines whether the anndata object is modified, but the two apply to different kinds of results. `copy` applies when a function modifies a measurement slot (`.X`, `.layers[...]`), including changes to the object's shape. `inplace` applies when a function derives a new result from the data.
 
 #### Examples
 
 ```python
-result = apt.tl.func(adata, ..., inplace=False)
+# The result is returned and the anndata object is left untouched
+result = alphapepttools.tl.func(adata, ..., key_added="result", inplace=False)
 assert isinstance(result, pd.DataFrame)
 
-result = apt.tl.func(adata, ..., inplace=True)
+# The result is stored in the anndata object and nothing is returned
+result = alphapepttools.tl.func(adata, ..., key_added="result", inplace=True)
 assert result is None
 ```
 


### PR DESCRIPTION
Document API behavior for reused keywords `copy` vs. `inplace`. This PR just proposes to formalize these conventions in `Contributing.md`

## Suggestion
- `copy` is used when the function acts on the measurement data (`.X`, `.layers`) ("The function either returns a modified anndata object or a new copy of an anndata object")
- `inplace` is used when the function generates summary statistics ("The function either modifies the anndata object or returns a dataframe")


## Implications
The current API is inconsistent in the following functions (review by Claude):

### Return types
- [x] `metrics.pooled_median_absolute_deviation` always returns `pd.DataFrame`, independent of `inplace`
- [ ] `metrics.total_intensity`, `metrics.number_detected`, `metrics.fraction_complete` return `np.ndarray` instead of `pd.DataFrame`

### Differential expression
Comment: This is known and on the roadmap, left it here to inform the refactor. @vbrennsteiner 
- [x] `tl.diff_exp_ebayes` returns `tuple[str, pd.DataFrame]`, `tl.diff_exp_alphaquant` returns `tuple[str, dict[str, pd.DataFrame]]`
- [ ] `tl.diff_exp_ttest` is annotated `pd.DataFrame | None`, but `None` is unreachable (validation raises) and collides with the "modified inplace" meaning of `None`
- [ ] `tl.diff_exp_ttest`, `tl.diff_exp_ebayes`, `tl.diff_exp_alphaquant` store nothing, no `inplace` and no `layer`

### Wrong/inconsistent keyword
- [ ] `metrics.coefficient_of_variation(..., copy=)` should be `inplace` **Breaking**
- [ ] `metrics.principal_component_regression` returns a `float` only, no `inplace`, result cannot be stored
- [ ] `layer` is positional in `pp.nanlog`, `pp.normalize`, `pp.scale_and_center`, `pp.scanpy_pycombat`, `pp.impute_gaussian`, `pp.impute_median`, `pp.impute_knn`, `tl.pca`, `tl.bpca` — must be keyword-only **Breaking**

### Missing `copy`
- [x] `pp.add_metadata` always returns a new object
- [ ] `pp.filter_by_metadata` always returns
- [ ] `pp.filter_data_completeness` mutates and returns the *same* object for `action="flag"`, but returns a copy for `action="drop"`
- [ ] `pp.drop_singleton_batches` always copies (and copies twice internally)
- [ ] Shape-changing functions (`pp.filter_*`, `pp.add_metadata`, `pp.drop_singleton_batches`) do not have a copy argument right now

### Inconsistent result key
- [ ] `key_added` (`metrics.coefficient_of_variation`), `column` (sample-level metrics), `var_colname` (`pp.filter_data_completeness`), `embeddings_name` (`tl.pca`/`tl.bpca`), `pca_key`/`pca_key_uns` (`metrics.principal_component_regression`) — standardize on `key_added`
- [ ] `metrics.calculate_qc_metrics` overrides every default column name of the functions it calls (`total_intensity` → `total_sample_intensity`, `number_detected` → `num_features_detected`, `fraction_complete` → `fraction_detected_features`)

### Bugs
- [ ] `pp.scanpy_pycombat(..., copy=False)` silently does nothing if the batch column contains NaNs: `coerce_nans_to_batch` rebinds `adata` to an internal copy, so the correction is discarded and `None` is returned
- [ ] `pp.filter_by_metadata` returns a *view*; a subsequent inplace `pp` call writes through into the parent object (anndata `FutureWarning`: will raise in future versions)

### Open decisions
- [ ] `tl.pca`/`tl.bpca` write only `.obsm`/`.varm`/`.uns`, so the new taxonomy puts them in the summary-statistics category (`inplace`), but both expose `copy` for scanpy compatibility — needs an explicit carve-out in the guide **Breaking**
- [ ] `pp.detect_special_values` is public in `pp` but takes `np.ndarray`, not `AnnData` — make it AnnData-facing or private
