### PR TITLE
Add LLM.txt configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,6 +58,7 @@ extensions = [
     "sphinx_autodoc_typehints",
     "sphinx_tabs.tabs",
     "sphinx.ext.mathjax",
+    "sphinx_llms_txt",
     "IPython.sphinxext.ipython_console_highlighting",
     "sphinxext.opengraph",
     *[p.stem for p in (HERE / "extensions").glob("*.py")],
@@ -106,6 +107,23 @@ intersphinx_mapping = {
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
 
+# -- Options for LLM.txt output ----------------------------------------------
+llms_txt_title = "AlphaPeptTools"
+
+llms_txt_summary = """
+AlphaPeptTools implements the full analysis pipeline for mass spectrometry proteomics.
+The package is built on the AnnData container.
+
+Available subpackages are:
+- `.io`: Read search engine outputs into standardized anndata format
+- `.pp`: Quality control and preprocessing of proteomics data
+- `.tl`: Statistical analysis of proteomics data (principal component analysis, differential expression)
+- `.pl`: Plotting and visualization functionalities
+- `.metrics`: Assess quality of analysis steps
+
+The API documentation provides detailed signatures for specific functions.
+Tutorials implement complete analysis pipelines and can be used to identify analysis strategies for specific proteomics experiment types.
+"""
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,7 +121,7 @@ Available subpackages are:
 - `.pl`: Plotting and visualization functionalities
 - `.metrics`: Assess quality of analysis steps
 
-The API documentation provides detailed signatures for specific functions.
+The API documentation provides detailed signatures for all public functions. Public functions further contain docstrings with usage examples.
 Tutorials implement complete analysis pipelines and can be used to identify analysis strategies for specific proteomics experiment types.
 """
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -122,7 +122,7 @@ Available subpackages are:
 - `.metrics`: Assess quality of analysis steps
 
 The API documentation provides detailed signatures for all public functions. Public functions further contain docstrings with usage examples.
-Tutorials implement complete analysis pipelines and can be used to identify analysis strategies for specific proteomics experiment types.
+Tutorials provide end-to-end analysis pipelines that double as templates for the respective proteomics experiment types.
 """
 
 # -- Options for HTML output -------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ optional-dependencies.doc = [
   "sphinx-autodoc-typehints",
   "sphinx-book-theme>=1",
   "sphinx-copybutton",
+  "sphinx-llms-txt",
   "sphinx-tabs",
   "sphinxcontrib-bibtex>=1",
   "sphinxext-opengraph",


### PR DESCRIPTION
Thank you @maltekuehl for suggesting this!

Adds the `sphinx_llms_txt` extension to the docs build. The extension automatically parses the documentation and adds a `llms.txt` to the build that provides an overview over the package. 

I configured the header so that it contains a high-level overview over the package. 