### PR TITLE
[feature] Allow for center/scale only in `apt.pp.scale_and_center` 

### DIFF
--- a/docs/notebooks/studies/study_05_multimodal.ipynb
+++ b/docs/notebooks/studies/study_05_multimodal.ipynb
@@ -1006,7 +1006,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "adata.X = (adata.X - np.nanmedian(adata.X, axis=0)).copy()\n",
+    "# Median center\n",
+    "apt.pp.scale_and_center(adata, scaler=\"robust\", layer=None, center=True, scale=False, copy=False)\n",
     "adata.layers[\"median_centered\"] = adata.X.copy()"
    ]
   },

--- a/src/alphapepttools/pp/data.py
+++ b/src/alphapepttools/pp/data.py
@@ -810,22 +810,34 @@ def data_columns_to_df(
 
 
 def scale_and_center(  # explicitly tested via test_pp_scale_and_center()
-    adata: ad.AnnData, scaler: str = "standard", layer: str | None = None, *, copy: bool = False
+    adata: ad.AnnData,
+    scaler: Literal["standard", "robust"] = "standard",
+    layer: str | None = None,
+    *,
+    center: bool = True,
+    scale: bool = True,
+    copy: bool = False,
 ) -> None | ad.AnnData:
-    """Scale and center data.
-
-    Either use standard or robust scaling. 'robust' scaling relies
-    on interquartile range and is more resistant to outliers. Scaling
-    operates on columns only for now.
+    """Scale and center features
 
     Parameters
     ----------
     adata
         AnnData object with data to scale.
     scaler
-        Sklearn scaler to use. Available scalers are 'standard' and 'robust'.
+        Sklearn scaler to use. Available scalers are
+            - `standard`: Mean centering and scaling by standard deviation
+            - `robust`: Median centering and scaling by provided quantiles.
     layer
         Name of the layer to scale. If None (default), the data matrix X is used.
+    center
+        Whether to center the data distribution around zero before scaling. If True
+            - `standard`: Shifts the feature distribution by its mean.
+            - `robust`: Shifts the feature distribution by its median.
+    scale
+        Whether to scale the data distribution:
+            - `standard`: Will scale the feature distribution by its standard distribution to unit variance.
+            - `scale`: Will scale the feature distribution by its (0.25, 0.75) interquartile range.
     copy
         Whether to return a modified copy (True) of the anndata object. If False (default)
         modifies the object inplace
@@ -861,13 +873,17 @@ def scale_and_center(  # explicitly tested via test_pp_scale_and_center()
         scale_and_center(adata, scaler="robust", layer="raw")
 
     """
+    if not (center or scale):
+        raise ValueError(
+            "Setting `center=False` and `scale=False` corresponds to an identity transform. Set at least one argument to `True`"
+        )
     adata = adata.copy() if copy else adata
     logging.info(f"pp.scale_and_center(): Scaling data with {scaler} scaler.")
 
     if scaler == "standard":
-        scaler = StandardScaler(with_mean=True, with_std=True)
+        scaler = StandardScaler(with_mean=center, with_std=scale)
     elif scaler == "robust":
-        scaler = RobustScaler(with_centering=True, with_scaling=True, quantile_range=(25.0, 75.0))
+        scaler = RobustScaler(with_centering=center, with_scaling=scale, quantile_range=(25.0, 75.0))
     else:
         raise NotImplementedError(f"Scaler {scaler} not implemented.")
 

--- a/src/alphapepttools/pp/data.py
+++ b/src/alphapepttools/pp/data.py
@@ -840,7 +840,7 @@ def scale_and_center(
         Whether to scale the feature distribution.
         If `True`:
             - `standard`: Divides the feature distribution by its standard deviation to unit variance.
-            - `robust`: Divides the feature distribution by its (0.25, 0.75) interquartile range.
+            - `robust`: Divides the feature distribution by its interquartile range, i.e. range between quantile (0.25, 0.75).
         Not applied if set to `False`.
     copy
         Whether to return a modified copy (True) of the anndata object. If False (default)
@@ -893,7 +893,7 @@ def scale_and_center(
     """
     if not (center or scale):
         raise ValueError(
-            "Setting `center=False` and `scale=False` corresponds to an identity transform. Set at least one argument to `True`"
+            "Setting `center=False` and `scale=False` leaves data unchanged. Set at least one argument to `True`"
         )
     adata = adata.copy() if copy else adata
     logging.info(f"pp.scale_and_center(): Scaling data with {scaler} scaler.")
@@ -901,7 +901,8 @@ def scale_and_center(
     if scaler == "standard":
         scaler = StandardScaler(with_mean=center, with_std=scale)
     elif scaler == "robust":
-        scaler = RobustScaler(with_centering=center, with_scaling=scale, quantile_range=(25.0, 75.0))
+        interquantile_range = (25.0, 75.0)
+        scaler = RobustScaler(with_centering=center, with_scaling=scale, quantile_range=interquantile_range)
     else:
         raise NotImplementedError(f"Scaler {scaler} not implemented.")
 

--- a/src/alphapepttools/pp/data.py
+++ b/src/alphapepttools/pp/data.py
@@ -831,16 +831,16 @@ def scale_and_center(
     layer
         Name of the layer to scale. If None (default), the data matrix X is used.
     center
-        Whether to center the data distribution around zero before scaling.
-        If `True`
+        Whether to center the feature distribution at zero.
+        If `True`:
             - `standard`: Shifts the feature distribution by its mean.
             - `robust`: Shifts the feature distribution by its median.
-        Not applied if set to `False`
+        Not applied if set to `False`.
     scale
-        Whether to scale the data distribution:
+        Whether to scale the feature distribution.
         If `True`:
-            - `standard`: Will scale the feature distribution by its standard distribution to unit variance.
-            - `scale`: Will scale the feature distribution by its (0.25, 0.75) interquartile range.
+            - `standard`: Divides the feature distribution by its standard deviation to unit variance.
+            - `robust`: Divides the feature distribution by its (0.25, 0.75) interquartile range.
         Not applied if set to `False`.
     copy
         Whether to return a modified copy (True) of the anndata object. If False (default)
@@ -861,7 +861,6 @@ def scale_and_center(
         import pandas as pd
         import numpy as np
         import alphapepttools as apt
-
 
         adata = ad.AnnData(
             X=np.array([[1, 10], [2, 20], [3, 30], [4, 40]]),
@@ -886,12 +885,10 @@ def scale_and_center(
         # Only scale, do not center
         apt.pp.scale_and_center(adata, scaler="standard", center=False, scale=True)
 
-
     See Also
     --------
     :class:`sklearn.preprocessing.StandardScaler`
     :class:`sklearn.preprocessing.RobustScaler`
-
 
     """
     if not (center or scale):

--- a/src/alphapepttools/pp/data.py
+++ b/src/alphapepttools/pp/data.py
@@ -809,7 +809,7 @@ def data_columns_to_df(
     return cast("pd.DataFrame", dataset)
 
 
-def scale_and_center(  # explicitly tested via test_pp_scale_and_center()
+def scale_and_center(
     adata: ad.AnnData,
     scaler: Literal["standard", "robust"] = "standard",
     layer: str | None = None,
@@ -817,7 +817,7 @@ def scale_and_center(  # explicitly tested via test_pp_scale_and_center()
     center: bool = True,
     scale: bool = True,
     copy: bool = False,
-) -> None | ad.AnnData:
+) -> ad.AnnData | None:
     """Scale and center features
 
     Parameters
@@ -827,26 +827,29 @@ def scale_and_center(  # explicitly tested via test_pp_scale_and_center()
     scaler
         Sklearn scaler to use. Available scalers are
             - `standard`: Mean centering and scaling by standard deviation
-            - `robust`: Median centering and scaling by provided quantiles.
+            - `robust`: Median centering and scaling by interquartile range.
     layer
         Name of the layer to scale. If None (default), the data matrix X is used.
     center
-        Whether to center the data distribution around zero before scaling. If True
+        Whether to center the data distribution around zero before scaling.
+        If `True`
             - `standard`: Shifts the feature distribution by its mean.
             - `robust`: Shifts the feature distribution by its median.
+        Not applied if set to `False`
     scale
         Whether to scale the data distribution:
+        If `True`:
             - `standard`: Will scale the feature distribution by its standard distribution to unit variance.
             - `scale`: Will scale the feature distribution by its (0.25, 0.75) interquartile range.
+        Not applied if set to `False`.
     copy
         Whether to return a modified copy (True) of the anndata object. If False (default)
         modifies the object inplace
 
     Returns
     -------
-    None | anndata.AnnData
-        If `copy=False` modifies the anndata object at layer inplace and returns None. If `copy=True`,
-        returns a modified copy.
+    If `copy=False` modifies the anndata object at layer inplace and returns None.
+    If `copy=True`, returns a modified copy.
 
     Examples
     --------
@@ -857,7 +860,8 @@ def scale_and_center(  # explicitly tested via test_pp_scale_and_center()
         import anndata as ad
         import pandas as pd
         import numpy as np
-        from alphapepttools.pp.data import scale_and_center
+        import alphapepttools as apt
+
 
         adata = ad.AnnData(
             X=np.array([[1, 10], [2, 20], [3, 30], [4, 40]]),
@@ -866,11 +870,28 @@ def scale_and_center(  # explicitly tested via test_pp_scale_and_center()
         )
 
         # Standard scaling (in-place)
-        scale_and_center(adata, scaler="standard")
+        apt.pp.scale_and_center(adata, scaler="standard")
 
         # Robust scaling on a specific layer
-        adata.layers["raw"] = adata.X.copy()
-        scale_and_center(adata, scaler="robust", layer="raw")
+        adata.layers["processed"] = adata.X.copy()
+        apt.pp.scale_and_center(adata, scaler="robust", layer="processed")
+
+    You can selectively center or scale the layer:
+
+    .. code-block:: python
+
+        # Only apply median centering
+        apt.pp.scale_and_center(adata, scaler="robust", center=True, scale=False)
+
+        # Only scale, do not center
+        apt.pp.scale_and_center(adata, scaler="standard", center=False, scale=True)
+
+
+    See Also
+    --------
+    :class:`sklearn.preprocessing.StandardScaler`
+    :class:`sklearn.preprocessing.RobustScaler`
+
 
     """
     if not (center or scale):

--- a/src/alphapepttools/pp/data.py
+++ b/src/alphapepttools/pp/data.py
@@ -833,8 +833,8 @@ def scale_and_center(
     center
         Whether to center the feature distribution at zero.
         If `True`:
-            - `standard`: Shifts the feature distribution by its mean.
-            - `robust`: Shifts the feature distribution by its median.
+            - `standard`: Mean-centering of the feature distribution.
+            - `robust`: Median-centering of the feature distribution.
         Not applied if set to `False`.
     scale
         Whether to scale the feature distribution.

--- a/tests/pp/test_data.py
+++ b/tests/pp/test_data.py
@@ -766,6 +766,52 @@ class TestScaleAndCenter:
 
         return adata, expected
 
+    @pytest.fixture
+    def anndata_center_only(self, example_data) -> tuple[ad.AnnData, dict[str, pd.DataFrame]]:
+        """Generate example anndata with ground truths (center only)"""
+        adata = _to_anndata(example_data)
+        adata.layers["new_layer"] = adata.X.copy()
+
+        expected = {
+            "standard": pd.DataFrame(
+                {"G1": [-1.0, 0.0, 1.0], "G2": [-1.0, 0.0, 1.0], "G3": [-1.0, 0.0, 1.0]},
+                index=["cell1", "cell2", "cell3"],
+            ),
+            "robust": pd.DataFrame(
+                {"G1": [-1.0, 0.0, 1.0], "G2": [-1.0, 0.0, 1.0], "G3": [-1.0, 0.0, 1.0]},
+                index=["cell1", "cell2", "cell3"],
+            ),
+        }
+
+        return adata, expected
+
+    @pytest.fixture
+    def anndata_scale_only(self, example_data) -> tuple[ad.AnnData, dict[str, pd.DataFrame]]:
+        """Generate example anndata with ground truths (scaling only)"""
+        adata = _to_anndata(example_data)
+        adata.layers["new_layer"] = adata.X.copy()
+
+        expected = {
+            "standard": pd.DataFrame(
+                {
+                    "G1": [1.22474487, 2.44948974, 3.67423461],
+                    "G2": [4.89897949, 6.12372436, 7.34846923],
+                    "G3": [8.5732141, 9.79795897, 11.02270384],
+                },
+                index=["cell1", "cell2", "cell3"],
+            ),
+            "robust": pd.DataFrame(
+                {
+                    "G1": [1.0, 2.0, 3.0],
+                    "G2": [4.0, 5.0, 6.0],
+                    "G3": [7.0, 8.0, 9.0],
+                },
+                index=["cell1", "cell2", "cell3"],
+            ),
+        }
+
+        return adata, expected
+
     @pytest.mark.parametrize("layer", [None, "new_layer"])
     @pytest.mark.parametrize("scaler", ["standard", "robust"])
     def test_scale_and_center_inplace(self, anndata_scale_and_center, scaler: str, layer: str) -> None:
@@ -789,6 +835,54 @@ class TestScaleAndCenter:
         adata_original = adata.copy()
 
         adata_new = apt.pp.scale_and_center(adata, scaler=scaler, layer=layer, copy=True)
+
+        assert isinstance(adata_new, ad.AnnData)
+
+        if layer is None:
+            assert np.all(np.isclose(adata_new.X, expected[scaler].values))
+            # Original object was not modified
+            assert np.all(np.isclose(adata.X, adata_original.X))
+
+        else:
+            assert np.all(np.isclose(adata_new.layers[layer], expected[scaler].values))
+            # Original object was not modified
+            assert np.all(np.isclose(adata.layers[layer], adata_original.layers[layer]))
+
+    @pytest.mark.parametrize(
+        "layer",
+        [None, "new_layer"],
+    )
+    @pytest.mark.parametrize(
+        "scaler",
+        ["standard", "robust"],
+    )
+    def test_scale_and_center__center_only(self, anndata_center_only, scaler: str, layer: str) -> None:
+        """Test that alphapepttools.pp.scale_and_center correctly returns a copy"""
+        adata, expected = anndata_center_only
+        adata_original = adata.copy()
+
+        adata_new = apt.pp.scale_and_center(adata, scaler=scaler, layer=layer, center=True, scale=False, copy=True)
+
+        assert isinstance(adata_new, ad.AnnData)
+
+        if layer is None:
+            assert np.allclose(adata_new.X, expected[scaler].values)
+            # Original object was not modified
+            assert np.allclose(adata.X, adata_original.X)
+
+        else:
+            assert np.allclose(adata_new.layers[layer], expected[scaler].values)
+            # Original object was not modified
+            assert np.allclose(adata.layers[layer], adata_original.layers[layer])
+
+    @pytest.mark.parametrize("layer", [None, "new_layer"])
+    @pytest.mark.parametrize("scaler", ["standard", "robust"])
+    def test_scale_and_center__scale_only(self, anndata_scale_only, scaler: str, layer: str) -> None:
+        """Test that alphapepttools.pp.scale_and_center correctly returns a copy"""
+        adata, expected = anndata_scale_only
+        adata_original = adata.copy()
+
+        adata_new = apt.pp.scale_and_center(adata, scaler=scaler, layer=layer, center=False, scale=True, copy=True)
 
         assert isinstance(adata_new, ad.AnnData)
 

--- a/tests/pp/test_data.py
+++ b/tests/pp/test_data.py
@@ -802,6 +802,13 @@ class TestScaleAndCenter:
             # Original object was not modified
             assert np.all(np.isclose(adata.layers[layer], adata_original.layers[layer]))
 
+    def test_scale_and_center_raises(self, anndata_scale_and_center):
+        """Test that scale_and_center raises when `center=False` and `scale=False`"""
+        adata, _ = anndata_scale_and_center
+
+        with pytest.raises(ValueError, match="Set at least one argument to `True`"):
+            apt.pp.scale_and_center(adata, center=False, scale=False)
+
 
 @pytest.fixture
 def data_test_completeness_filter():

--- a/tests/pp/test_data.py
+++ b/tests/pp/test_data.py
@@ -857,7 +857,7 @@ class TestScaleAndCenter:
         ["standard", "robust"],
     )
     def test_scale_and_center__center_only(self, anndata_center_only, scaler: str, layer: str) -> None:
-        """Test that alphapepttools.pp.scale_and_center correctly returns a copy"""
+        """Test that alphapepttools.pp.scale_and_center only centers the data if `scale=False`"""
         adata, expected = anndata_center_only
         adata_original = adata.copy()
 
@@ -878,7 +878,7 @@ class TestScaleAndCenter:
     @pytest.mark.parametrize("layer", [None, "new_layer"])
     @pytest.mark.parametrize("scaler", ["standard", "robust"])
     def test_scale_and_center__scale_only(self, anndata_scale_only, scaler: str, layer: str) -> None:
-        """Test that alphapepttools.pp.scale_and_center correctly returns a copy"""
+        """Test that alphapepttools.pp.scale_and_center only scales the data if `center=False`"""
         adata, expected = anndata_scale_only
         adata_original = adata.copy()
 


### PR DESCRIPTION
Extend functionality of scaling preprocessing step, as used in the multimodal notebook. Especially in TMT experiments, users often want to median-center (but not scale). This is now one special case of the function

This PR
1. Updates the function and allows users to optionally  center-only or scale-only.
```
apt.pp.scale_and_center(..., center=True/False, scale=True/False)
```
3. Adds tests
4. Use instead of custom median-centering logic in multimodal notebook (validated that the arrays are exactly numerically equivalent)

